### PR TITLE
Fix class name typo and method call issues

### DIFF
--- a/src/classifier.py
+++ b/src/classifier.py
@@ -9,7 +9,7 @@ import torch
 from typing import Optional
 
 
-class Certainity_classifier:
+class Certainty_classifier:
     def __init__(self, llm, problem, threshold):
         self.llm = llm
         self.problem = problem
@@ -49,7 +49,7 @@ class Certainity_classifier:
 
 
     def __call__(self):
-        self._compute_spp(self.problem)
+        self._compute_spp()
 
         # Self-Perplexity를 기반으로 한 Certain / Uncertain 여부 판단
         if self.spp_ppl >= self.threshold:
@@ -131,7 +131,7 @@ def main():
 
     res = []
     for idx, data in tqdm(enumerate(dataset)):
-        runner = Certainity_classifier(model, data['question'])
+        runner = Certainty_classifier(model, data['question'], threshold=10.0)
         result = runner()
         tmp = {
             "id": data['id'],

--- a/src/models.py
+++ b/src/models.py
@@ -16,7 +16,7 @@ class ModelWrapper:
         self.model, self.tokenizer = load_model(self.args)
 
 
-class Certainity_classifier:
+class Certainty_classifier:
     def __init__(self, llm, problem, threshold):
         self.llm = llm
         self.problem = problem
@@ -56,7 +56,7 @@ class Certainity_classifier:
 
 
     def __call__(self):
-        self._compute_spp(self.problem)
+        self._compute_spp()
 
         # Self-Perplexity를 기반으로 한 Certain / Uncertain 여부 판단
         if self.spp_ppl >= self.threshold:
@@ -138,7 +138,7 @@ def main():
 
     res = []
     for idx, data in tqdm(enumerate(dataset)):
-        runner = Certainity_classifier(model, data['question'])
+        runner = Certainty_classifier(model, data['question'], threshold=10.0)
         result = runner()
         tmp = {
             "id": data['id'],


### PR DESCRIPTION
Fixes #1 과 Fixes #4 입니다. 변경사항은 Certainity를 Certainty로 오타 수정, _compute_spp() 호출시 self.problem 인자 제거 (이미 인스턴스 변수로 있어서 불필요), threshold 기본값 10.0으로 임시 설정 (나중에 조정 필요할 수 있음). 로컬에서 실행해보니 정상 작동합니다.